### PR TITLE
chore(server): switch runtime scripts to Bun

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "bun dist/index.js",
     "dev": "bun --hot src/index.ts",
-    "build": "bun build src/index.ts --outdir dist",
+    "build": "bun build src/index.ts --outdir dist --target=bun",
     "test": "jest",
     "prettier": "prettier --check 'src/**/*.ts'",
     "format": "prettier --write 'src/**/*.ts'",


### PR DESCRIPTION
## Summary
- switch server runtime scripts to Bun
- keep Jest tests while removing `nodemon` and `ts-node`

## Testing
- not run (commit only)

## Notes
- `server/package.json` now uses `bun --hot` for dev, `bun build` for build, and `bun` to start
