### PR TITLE
ci(release): prevent duplicate release notes and keep intro + auto sections

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -112,6 +112,7 @@ jobs:
   publish:
     name: 🚀 Publish
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -145,7 +145,31 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Check existing release
+        id: release_check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag
+              });
+              core.setOutput('exists', 'true');
+              core.info(`Release already exists for tag ${tag}. Publish step will be skipped.`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.setOutput('exists', 'false');
+                core.info(`No release found for tag ${tag}.`);
+              } else {
+                throw error;
+              }
+            }
+
       - name: Publish release
+        if: steps.release_check.outputs.exists != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
@@ -155,6 +179,6 @@ jobs:
           body: |
             Micro Banking Core is a local-first desktop banking app for small-scale operations.
             It provides admin-managed workflows for agents, clients, account lifecycle, and accounting, powered by a Tauri + Bun + Prisma stack.
-
+          append_body: false
           generate_release_notes: true
           files: ${{ steps.collect.outputs.files }}


### PR DESCRIPTION
  ## Summary

  This PR hardens the release workflow to avoid duplicate release content when a tag release already exists.

  It keeps the intended format:
  1. Custom short app description (intro)
  2. Auto-generated `What's Changed`
  3. Auto-generated `New Contributors`

  ## Problem

  A release could end up with repeated sections when publish logic runs against an already existing release/
  tag context.

  ## Changes

  - Updated `.github/workflows/release-tag.yml`:
    - Added a `Check existing release` step using `actions/github-script` and `getReleaseByTag`.
    - Publish step now runs only when no release exists for the tag:
      - `if: steps.release_check.outputs.exists != 'true'`
    - Set `append_body: false` explicitly in `softprops/action-gh-release`.

  ## Result

  - No accidental duplicate notes on re-run/re-publish scenarios.
  - Release notes remain clean and predictable with custom intro + generated changelog sections.

  ## Scope

  - CI workflow only (`release-tag.yml`)
  - No application/runtime/business logic changes.

 