### PR TITLE
docs: fix README anchor links and use GitHub security reporting flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,3 @@ server/src/generated/
 
 # local/generated build artifacts and notes
 desktop/resources/
-point.md
-PR.md
-summary.md


### PR DESCRIPTION
  ## Summary

  This PR fixes broken README table-of-contents navigation and updates the security reporting policy to use
  GitHub’s standard private vulnerability flow.

  ## Changes

  ### 1) README anchor fix
  - Added explicit anchor IDs for all major sections.
  - Updated TOC links to target these IDs reliably.
  - Corrected `CI/CD` TOC anchor to `#ci-cd`.
  - Stop tracking unnecessary document files
  
  File:
  - `README.md`

  ### 2) SECURITY reporting flow update
  - Removed personal email-based reporting.
  - Switched to GitHub standard private disclosure flow:
    - `Security` tab
    - `Advisories`
    - `Report a vulnerability`

  File:
  - `SECURITY.md`

  ## Why


  ## Scope

  - Documentation only.
  - No application, build, runtime, or business logic changes.
